### PR TITLE
Expose HttpMethod enum across modules and support primitives in native LRU cache

### DIFF
--- a/src/native/cache/lru_cache.cc
+++ b/src/native/cache/lru_cache.cc
@@ -180,7 +180,7 @@ Napi::Value LRUCache::Set(const Napi::CallbackInfo& info) {
     // Update existing entry
     CacheEntry& entry = *(it->second);
     // Store a new reference and release the old one
-    entry.value.Reset(value.IsObject() ? value.As<Napi::Object>() : Napi::Object::New(env));
+    entry.value.Reset(value);
     entry.expiry = expiry;
 
     // Move to front of list
@@ -190,7 +190,7 @@ Napi::Value LRUCache::Set(const Napi::CallbackInfo& info) {
     // Create new entry
     CacheEntry newEntry;
     newEntry.key = key;
-    newEntry.value = Napi::Persistent(value.IsObject() ? value.As<Napi::Object>() : Napi::Object::New(env));
+    newEntry.value = Napi::Persistent(value);
     newEntry.expiry = expiry;
 
     // Add to front of list

--- a/src/native/cache/lru_cache.h
+++ b/src/native/cache/lru_cache.h
@@ -33,7 +33,7 @@ private:
   // Type definitions for cache implementation
   struct CacheEntry {
     std::string key;
-    Napi::ObjectReference value;
+    Napi::Reference<Napi::Value> value;
     int64_t expiry;  // Timestamp for TTL (0 = no expiry)
   };
 

--- a/src/routing/router.ts
+++ b/src/routing/router.ts
@@ -13,21 +13,10 @@ import { IncomingMessage, ServerResponse } from 'node:http';
 import { URL } from 'node:url';
 import { MiddlewareHandler, getRouteMetadata, composeMiddleware, parseBody } from '../types/index.js';
 import { Container } from '../di/container.js';
+import { HttpMethod } from '../http/http-method.js';
 
-/**
- * HTTP method types for routing
- */
-export type HttpMethod =
-  | 'GET'
-  | 'POST'
-  | 'PUT'
-  | 'DELETE'
-  | 'PATCH'
-  | 'HEAD'
-  | 'OPTIONS'
-  | 'CONNECT'
-  | 'TRACE'
-  | '*';
+// Re-export for compatibility with previous imports from this module
+export { HttpMethod } from '../http/http-method.js';
 
 // Constants
 export const STATIC = 0;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ import { parseBody as parseBodyImpl } from '../http/body-parser.js';
 import { composeMiddleware as composeMiddlewareImpl } from '../middleware/middleware.js';
 import { getRouteMetadata as getRouteMetadataImpl } from '../decorators/route-decorators.js';
 import { Logger as FrameworkLogger } from '../utils/logger.js';
+import { HttpMethod } from '../http/http-method.js';
 
 /**
  * Types module
@@ -152,16 +153,7 @@ export class HttpException extends Error {
 /**
  * HTTP methods enum
  */
-export enum HttpMethod {
-  GET = 'GET',
-  POST = 'POST',
-  PUT = 'PUT',
-  DELETE = 'DELETE',
-  PATCH = 'PATCH',
-  HEAD = 'HEAD',
-  OPTIONS = 'OPTIONS',
-  ALL = '*'
-}
+export { HttpMethod };
 
 export const HTTP_CONSTANTS = {
   CRLF: Buffer.from('\r\n'),

--- a/test/unit/native/lru-cache.test.ts
+++ b/test/unit/native/lru-cache.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for the LRUCache native module
+ */
+
+import { loadNativeBinding } from '../../../src/native/index.js';
+
+describe('LRUCache Native Module', () => {
+  let nativeModule: any;
+  let LRUCache: any;
+
+  beforeAll(() => {
+    nativeModule = loadNativeBinding();
+
+    if (!nativeModule) {
+      console.warn('Native module not available. Skipping LRUCache tests.');
+    } else {
+      LRUCache = nativeModule.LRUCache;
+    }
+  });
+
+  // Helper to skip when the native module is missing
+  const skipIfNoNative = () => {
+    if (!nativeModule || !LRUCache) {
+      return true;
+    }
+    return false;
+  };
+
+  test('should store and retrieve primitive values', () => {
+    if (skipIfNoNative()) return;
+    const cache = new LRUCache();
+    cache.set('num', 42);
+    cache.set('str', 'value');
+    expect(cache.get('num')).toBe(42);
+    expect(cache.get('str')).toBe('value');
+  });
+});
+

--- a/test/unit/routing/all-route.test.ts
+++ b/test/unit/routing/all-route.test.ts
@@ -1,0 +1,27 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import { Router, HttpMethod } from '../../../src/routing/router.js';
+
+describe('Router ALL method', () => {
+  test('registers handler for all HTTP methods', () => {
+    const router = new Router();
+    const handler = jest.fn(async () => 'ok');
+
+    router.all('/test', handler);
+
+    const methods = [
+      HttpMethod.GET,
+      HttpMethod.POST,
+      HttpMethod.PUT,
+      HttpMethod.DELETE,
+      HttpMethod.PATCH,
+      HttpMethod.OPTIONS,
+      HttpMethod.HEAD
+    ];
+
+    for (const method of methods) {
+      const match = router.findRoute(method, '/test');
+      expect(match).not.toBeNull();
+      expect(match!.route.handler).toBe(handler);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- keep primitive values when using the native LRU cache by storing generic Napi references
- expose a single shared HttpMethod enum via router and types modules so `HttpMethod.ALL` routes register correctly
- test LRU cache primitive round trips and router.all handler registration for standard methods

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c9c879c7c832a87fca3a44a8bc1c5